### PR TITLE
Java compatibility 1.8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -193,6 +193,10 @@ signing {
 }
 
 tasks {
+    withType<JavaCompile> {
+        sourceCompatibility = JavaVersion.VERSION_1_8.toString()
+        targetCompatibility = JavaVersion.VERSION_1_8.toString()
+    }
 
     withType<KotlinCompile> {
         kotlinOptions.jvmTarget = "11"


### PR DESCRIPTION


./gradle clean build publishToMavenLocal  - successful

target is set to 1.8:
![image](https://user-images.githubusercontent.com/28933068/97715208-2a98a300-1ad3-11eb-9aa7-e66765d169a2.png)

